### PR TITLE
Switch build

### DIFF
--- a/csp-billing-adapter-k8s.spec
+++ b/csp-billing-adapter-k8s.spec
@@ -15,9 +15,8 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-%{?!python_module:%define python_module() python-%{**} python3-%{**}}
-%global skip_python2 1
-%define pythons python3
+%{?sle15_python_module_pythons}
+
 Name:           csp-billing-adapter-k8s
 Version:        0.4.0
 Release:        0
@@ -26,13 +25,14 @@ License:        Apache-2.0
 Group:          Development/Languages/Python
 URL:            https://github.com/SUSE-Enceladus/%{name}
 Source:         https://files.pythonhosted.org/packages/source/c/%{name}/%{name}-%{version}.tar.gz
-BuildRequires:  python3-kubernetes
 BuildRequires:  fdupes
 BuildRequires:  python-rpm-macros
-BuildRequires:  %{python_module setuptools}
-BuildRequires:  %{python_module pluggy}
-BuildRequires:  %{python_module kubernetes}
 BuildRequires:  %{python_module csp-billing-adapter}
+BuildRequires:  %{python_module kubernetes}
+BuildRequires:  %{python_module pip}
+BuildRequires:  %{python_module pluggy}
+BuildRequires:  %{python_module setuptools}
+BuildRequires:  %{python_module wheel}
 %if %{with test}
 BuildRequires:  %{python_module pytest}
 BuildRequires:  %{python_module coverage}
@@ -53,10 +53,10 @@ storage of data using k8s resources.
 %autosetup -n %{name}-%{version}
 
 %build
-%python_build
+%pyproject_wheel
 
 %install
-%python_install
+%pyproject_install
 %python_expand %fdupes %{buildroot}%{$python_sitelib}
 
 %check


### PR DESCRIPTION
Switch the interpreter with which we build the package. Python 3.11 for SLE or other interpreters depending on build service defintions.